### PR TITLE
Increase Operators Horizontal Reach

### DIFF
--- a/lib/smache/mitigator.ex
+++ b/lib/smache/mitigator.ex
@@ -62,15 +62,19 @@ defmodule Smache.Mitigator do
     delegator
   end
 
+  defp rand_robin() do
+    :"operator_#{:rand.uniform(16)}"
+  end
+
   defp distributed_put_or_post(delegator, args) do
     [key, data] = args
 
-    GenServer.call({:"operator_#{:rand.uniform(4)}", delegator}, {:put_or_post, {key, data}})
+    GenServer.call({rand_robin(), delegator}, {:put_or_post, {key, data}})
   end
 
   defp distributed_get(delegator, args) do
     [key] = args
 
-    GenServer.call({:"operator_#{:rand.uniform(4)}", delegator}, {:get, {key}})
+    GenServer.call({rand_robin(), delegator}, {:get, {key}})
   end
 end

--- a/lib/smache/supervisor.ex
+++ b/lib/smache/supervisor.ex
@@ -18,7 +18,7 @@ defmodule Smache.Supervisor do
     ]
 
     operators =
-      1..4
+      1..16
       |> Enum.map(fn name ->
         uniq = :"operator_#{name}"
         worker(Operator, [[name: uniq]], id: uniq)


### PR DESCRIPTION
Go from 4 Operators to 16 to reduce even more back pressure.

```ex
# Pretend 2k requests
requests = 0..2000 |> Enum.map(fn _ -> :rand.uniform(16) end)

# result
[2, 12, 16, 13, 13, 11, 14, 10, 15, 13, 7, 14, 16, 14, 3, 9, 13, 1, 5, 6, 1, 16,
 14, 13, 1, 14, 1, 2, 6, 15, 4, 9, 8, 9, 9, 10, 8, 2, 2, 8, 3, 16, 9, 4, 9, 9,
 3, 16, 2, 5, ...]

# 16 GenServers
1..16 |>
Enum.map(fn gen_server ->
  # this is heavy but worth the calc ops
  requests |> Enum.count(&(&1 == gen_server))
end)

# result
[116, 108, 128, 117, 119, 123, 126, 134, 135, 127, 152, 119, 138, 112, 123, 123]
```